### PR TITLE
Workspace Restructure (Linear Algebra

### DIFF
--- a/.github/instructions/linear.instructions.md
+++ b/.github/instructions/linear.instructions.md
@@ -204,6 +204,16 @@ Calculus Repo Setup (Calculus)             ← new repo built from scratch in ne
 
 ---
 
+## Execution Pacing
+
+When executing a multi-phase milestone or any multi-step task:
+
+- Complete one phase (or major step), then **stop and check in** before proceeding to the next.
+- A major step is a phase boundary, a completed issue group, or any point where a meaningful verification just passed (e.g. tests green, docs build clean).
+- Do not chain phases together automatically — wait for explicit user confirmation to continue.
+
+---
+
 ## Planning Workflow: Markdown First, Linear for Execution
 
 Use this default workflow for non-trivial work:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,24 +28,23 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-buildpkg@v1
-
+      - uses: julia-actions/cache@v3
+      - name: Instantiate workspace
+        run: julia --project=. -e 'using Pkg; Pkg.instantiate()'
       - name: Run tests
-        run: >
-          julia --project=. --color=yes test/runtests.jl
+        run: julia --project=. --color=yes -e 'using Pkg; Pkg.test()'
 
   docs-build:
     name: Build Documentation
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check for docs/src changes
@@ -59,18 +58,19 @@ jobs:
           else
             echo "docs_changed=false" >> $GITHUB_OUTPUT
           fi
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         if: steps.docs-changes.outputs.docs_changed == 'true'
         with:
           version: '1'
           arch: x64
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v3
         if: steps.docs-changes.outputs.docs_changed == 'true'
-      - uses: julia-actions/julia-buildpkg@v1
+      - name: Instantiate docs workspace
         if: steps.docs-changes.outputs.docs_changed == 'true'
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
       - name: Build documentation
         if: steps.docs-changes.outputs.docs_changed == 'true'
-        run: julia --project=. --color=yes docs/make.jl
+        run: julia --project=docs --color=yes docs/make.jl
       - name: Skip docs build (no relevant changes)
         if: steps.docs-changes.outputs.docs_changed == 'false'
         run: echo "No docs or src changes detected, skipping docs build."
@@ -81,7 +81,7 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Fetch full history for path change detection
           
@@ -112,21 +112,23 @@ jobs:
           
       - name: Setup Julia
         if: steps.docs-changes.outputs.docs_changed == 'true'
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v3
         with:
           version: '1'
           arch: x64
           
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v3
         if: steps.docs-changes.outputs.docs_changed == 'true'
-        
-      - uses: julia-actions/julia-buildpkg@v1
+        continue-on-error: true
+
+      - name: Instantiate docs workspace
         if: steps.docs-changes.outputs.docs_changed == 'true'
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'
+        continue-on-error: true
 
       - name: Generate documentation and deploy
         if: steps.docs-changes.outputs.docs_changed == 'true'
-        run: >
-          julia --project=. --color=yes docs/make.jl
+        run: julia --project=docs --color=yes docs/make.jl
         env: # needed for pushing to gh-pages branch
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -420,6 +420,7 @@ $RECYCLE.BIN/
 #                              Miscellaneous                                   #
 ################################################################################
 /Manifest.toml
+notebooks/Manifest.toml
 .CondaPkg/
 docs/src/Linear\ Algebra\ Extra/
 docs/src/Linear Algebra Capacities/

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,11 @@
 name = "Linear_Algebra"
+uuid = "3561693b-e867-4865-8168-321e504a4e51"
+version = "0.1.0"
+license = "MIT"
 authors = ["Aron T"]
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DrWatson = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
@@ -20,3 +22,6 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 [compat]
 DrWatson = "2.16.0"
 julia = "1.12"
+
+[workspace]
+projects = ["test", "docs"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ authors = ["Aron T"]
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-DrWatson = "634d3b9d-ee7a-5ddf-bec9-22491ea816e1"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 LAlatex = "2feda2f4-7604-459e-bd73-51e960cd9dcb"
@@ -20,7 +19,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
-DrWatson = "2.16.0"
 julia = "1.12"
 
 [workspace]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Linear_Algebra = "3561693b-e867-4865-8168-321e504a4e51"
+
+[compat]
+Documenter = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,5 @@
 CI = get(ENV, "CI", nothing) == "true" || get(ENV, "GITHUB_TOKEN", nothing) !== nothing
-using DrWatson, Documenter, Dates
+using Documenter, Dates
 using Linear_Algebra
 
 @info "Building Documentation"

--- a/notebooks/Linear_Algebra_Basics.ipynb
+++ b/notebooks/Linear_Algebra_Basics.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 2,
    "id": "d841149c",
    "metadata": {},
    "outputs": [
@@ -28,10 +28,6 @@
     "# Set up Revise.jl for automatic code reloading\n",
     "# This only needs to be run once at the beginning of your notebook session\n",
     "using Revise\n",
-    "using DrWatson\n",
-    "\n",
-    "# Activate the project\n",
-    "quickactivate(@__DIR__, \"Linear_Algebra\")\n",
     "\n",
     "# Load the package \n",
     "using Linear_Algebra\n",

--- a/notebooks/Linear_Algebra_Geometry.ipynb
+++ b/notebooks/Linear_Algebra_Geometry.ipynb
@@ -8,28 +8,37 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## General Stuff"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "NamedTuple()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Set up Revise.jl for automatic code reloading\n",
     "# This only needs to be run once at the beginning of your notebook session\n",
     "using Revise\n",
-    "using DrWatson\n",
-    "\n",
-    "# Activate the project\n",
-    "quickactivate(@__DIR__, \"Linear_Algebra\")\n",
     "\n",
     "# Load the package \n",
-    "using Linear_Algebra"
+    "using Linear_Algebra\n",
+    "\n",
+    "LAlatex.set_backend!(:symbolics)\n",
+    "LAlatex.reset_display_defaults!()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## General Stuff"
    ]
   },
   {
@@ -420,24 +429,6 @@
    "metadata": {},
    "source": [
     "## Linear Maps"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set up Revise.jl for automatic code reloading\n",
-    "# This only needs to be run once at the beginning of your notebook session\n",
-    "using Revise\n",
-    "using DrWatson\n",
-    "\n",
-    "# Activate the project\n",
-    "quickactivate(@__DIR__, \"Linear_Algebra\")\n",
-    "\n",
-    "# Load the package \n",
-    "using Linear_Algebra"
    ]
   },
   {
@@ -929,24 +920,6 @@
    "metadata": {},
    "source": [
     "## Linear Systems"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Set up Revise.jl for automatic code reloading\n",
-    "# This only needs to be run once at the beginning of your notebook session\n",
-    "using Revise\n",
-    "using DrWatson\n",
-    "\n",
-    "# Activate the project\n",
-    "quickactivate(@__DIR__, \"Linear_Algebra\")\n",
-    "\n",
-    "# Load the package \n",
-    "using Linear_Algebra"
    ]
   },
   {

--- a/notebooks/Project.toml
+++ b/notebooks/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
+Linear_Algebra = "3561693b-e867-4865-8168-321e504a4e51"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+
+[compat]
+julia = "1.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Linear_Algebra = "3561693b-e867-4865-8168-321e504a4e51"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+julia = "1.10"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
-using DrWatson, Test
-@quickactivate "Linear_Algebra"
+using Test
 
 # Set headless mode for CI before loading module
 ENV["GKSwstype"] = "100"

--- a/test/test_linear_algebra_basic.jl
+++ b/test/test_linear_algebra_basic.jl
@@ -1,7 +1,6 @@
 using Test
 
 using Linear_Algebra
-using GeometryBasics, LinearAlgebra
 
 @testset "linear_algebra_basic.jl Tests" begin
     @testset "lin_ind_vec" begin

--- a/test/test_linear_algebra_geometry.jl
+++ b/test/test_linear_algebra_geometry.jl
@@ -4,7 +4,6 @@ using Test
 ENV["GKSwstype"] = "100"  # Set GKS to use headless mode
 
 using Linear_Algebra
-using GeometryBasics, LinearAlgebra
 
 # Ensure plots directory exists for plotting tests
 if !isdir("plots")

--- a/test/test_linear_algebra_transform.jl
+++ b/test/test_linear_algebra_transform.jl
@@ -4,7 +4,6 @@ using Test
 ENV["GKSwstype"] = "100"  # Set GKS to use headless mode
 
 using Linear_Algebra
-using GeometryBasics, LinearAlgebra
 
 @testset "linear_algebra_transform.jl Tests" begin
     


### PR DESCRIPTION
Implements the Julia workspace restructure for Linear_Algebra, replicated from the Math Foundations milestone.

**Phase 1 — Project structure:**
- Add uuid, version, license to root Project.toml
- Add [workspace] section (test, docs members)
- Create test/Project.toml and docs/Project.toml
- Create notebooks/Project.toml
- Remove DrWatson quickactivate from test/runtests.jl and docs/make.jl
- Remove redundant using statements from test files (@reexport covers these)

**Phase 2 — CI & cleanup:**
- Upgrade all GitHub Actions to Node.js 24 (checkout@v5, setup-julia@v3, cache@v3)
- Remove julia-buildpkg, add explicit Pkg.instantiate() steps
- Switch test job to Pkg.test() invocation
- Switch docs jobs to --project=docs
- Remove DrWatson from root [deps] and [compat]

Closes FOU-45, FOU-46, FOU-47, FOU-48, FOU-49, FOU-50, FOU-51, FOU-52, FOU-53, FOU-43, FOU-54, FOU-55, FOU-56, FOU-57