### PR TITLE
Adopt canonical muted color palette + Inter font for Documenter theme

### DIFF
--- a/docs/src/assets/custom.css
+++ b/docs/src/assets/custom.css
@@ -1,5 +1,27 @@
 /* Custom styles for cross-site navigation and branding */
 
+@import url('https://fonts.googleapis.com/css?family=Inter:400,500,700');
+
+/* ============================================================
+ * FourM font override
+ *
+ * Inter, chosen 2026-08-04 after live comparison against
+ * Documenter's native default (Lato), Roboto, and Raleway (used
+ * on the Franklin main site) -- pairs well with Raleway there.
+ *
+ * Scoped to body/UI text only -- deliberately does NOT touch:
+ *   - .is-family-monospace / .is-family-code (JuliaMono stack)
+ *     -- changing this would make code unreadable/misaligned.
+ *   - MathJax-rendered math (mjx-container etc.) -- MathJax3
+ *     renders its own fonts independent of page CSS, and
+ *     Documenter's headings don't set their own font-family
+ *     (they inherit from body), so this one override is
+ *     sufficient without a separate heading rule.
+ * ============================================================ */
+body, button, input, optgroup, select, textarea {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+}
+
 /* Site navigation footer styling */
 .site-navigation {
     margin-top: 2rem;
@@ -52,15 +74,15 @@
         background-color: #2b2b2b;
         border-color: #404040;
     }
-    
+
     .site-navigation h4 {
         color: #ffffff;
     }
-    
+
     .site-navigation ul li a {
         color: #58a6ff;
     }
-    
+
     .site-navigation ul li a:hover {
         color: #79c0ff;
     }
@@ -71,11 +93,11 @@
     .site-navigation {
         padding: 1rem;
     }
-    
+
     .site-navigation h4 {
         font-size: 0.9rem;
     }
-    
+
     .site-navigation ul li a {
         font-size: 0.85rem;
     }
@@ -97,4 +119,44 @@ html[data-theme="dark"] .site-navigation ul li a {
 
 html[data-theme="dark"] .site-navigation ul li a:hover {
     color: var(--documenter-dark-link-hover);
+}
+
+/* ============================================================
+ * FourM muted color palette override
+ *
+ * Documenter's default light theme's global link color
+ * (a{color:#2e63b8}) is a saturated blue that reads as "neon"
+ * against the site's grays. Replaces it with the same muted
+ * blue-gray family chosen for the Franklin main site's sidebar
+ * (see math_tech_study/_css/documenter-theme-alignment.css and
+ * desktop-sidebar.css) for whole-domain visual consistency.
+ *
+ * Scope is intentionally narrow: Documenter's headings, sidebar
+ * active-state, and docstring badges are already muted in the
+ * shipped theme and don't need touching -- only the base anchor
+ * color (and the two other selectors below that reuse it) do.
+ * ============================================================ */
+a {
+    color: #4a6b85;
+}
+
+a:hover {
+    color: #2c3e50;
+}
+
+.outdated-warning-overlay a {
+    color: #4a6b85;
+}
+
+#documenter .docs-sidebar form.docs-search > input.is-active {
+    border-color: #4a6b85;
+    box-shadow: 0 0 0 0.125em rgba(74, 107, 133, 0.25);
+}
+
+details.docstring > summary::before {
+    color: #4a6b85;
+}
+
+.content a code {
+    color: #4a6b85;
 }


### PR DESCRIPTION
## Summary
- Replaces `docs/src/assets/custom.css` with the new canonical version from `math_tech_study/project_resources/docs-assets/custom.css`.
- Muted color: Documenter's saturated default link color (`#2e63b8`) and docstring chevron (`#2E63BD`) replaced with the same muted blue-gray family chosen for the Franklin main site's sidebar reskin.
- Font: Lato → Inter for body/UI text, chosen after live side-by-side comparison against Lato (Documenter's native default, also what docs.julialang.org uses as-is), Roboto, and Raleway (used on the Franklin main site — Inter pairs well with it).
- Deliberately untouched: `.is-family-monospace`/code fonts (JuliaMono) and MathJax-rendered math — confirmed via testing, not just assumed.

This is the repo the palette/font were actually developed and tested against (live via LiveServer through several iterations).

Part of the FourM website domain takeover plan (`math_tech_study/_research/fourm-website-domain-takeover-workplan.md`), Phase 6 (Documenter sub-site theme).

## Test plan
- [x] `typos` clean
- [x] Local `docs/make.jl` build succeeds
- [x] Verified live via LiveServer through multiple iterations — color, font (Lato → Roboto → Inter comparison), math rendering, code monospace, docstring chevron all confirmed correct
- [ ] CI passes on this PR